### PR TITLE
Replace default style scss with css

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -94,7 +94,7 @@
   },
   "schematics": {
     "@schematics/angular:component": {
-      "style": "scss"
+      "style": "css"
     },
     "@schematics/angular:directive": {
       "prefix": ""


### PR DESCRIPTION
CSS is used in the base app for style. Just to keep things more consistent, on `ng generate component ...` the default style should be CSS as well.