### PR TITLE
fix configure Angular proxy for /api to backend server

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -58,7 +58,8 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "buildTarget": "reactive-angular-course:build"
+            "buildTarget": "reactive-angular-course:build",
+             "proxyConfig": "proxy.json"
           },
           "configurations": {
             "production": {


### PR DESCRIPTION
This PR fixes an issue where API requests to /api/courses were returning HTML instead of JSON during local development.